### PR TITLE
Only export the symbols of the public API in the shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(lpsolve_src
   URL https://github.com/ethz-asl/thirdparty_library_binaries/raw/master/lp_solve_5.5.2.0_source.tar.gz
   UPDATE_COMMAND ""
+  PATCH_COMMAND patch < ${PROJECT_SOURCE_DIR}/lpsolve.patch
   CONFIGURE_COMMAND cd ../lpsolve_src && pwd && cp ${PROJECT_SOURCE_DIR}/CMakeLists_lpsolve.txt ../lpsolve_src/CMakeLists.txt && cmake -DCMAKE_INSTALL_PREFIX=${CATKIN_DEVEL_PREFIX} .
   BUILD_COMMAND cd ../lpsolve_src && make -j8
   INSTALL_COMMAND cd ../lpsolve_src && make install -j8 && pwd

--- a/CMakeLists_lpsolve.txt
+++ b/CMakeLists_lpsolve.txt
@@ -6,6 +6,10 @@ add_definitions(-O3 -DYY_NEVER_INTERACTIVE -DPARSER_LP -DINVERSE_ACTIVE=INVERSE_
 include_directories(bfp bfp/bfp_LUSOL bfp/bfp_LUSOL/LUSOL colamd shared ${PROJECT_SOURCE_DIR})
 
 add_library(${PROJECT_NAME} SHARED lp_MDO.c shared/commonlib.c colamd/colamd.c shared/mmio.c shared/myblas.c ini.c fortify.c lp_rlp.c lp_crash.c bfp/bfp_LUSOL/lp_LUSOL.c bfp/bfp_LUSOL/LUSOL/lusol.c lp_Hash.c lp_lib.c lp_wlp.c lp_matrix.c lp_mipbb.c lp_MPS.c lp_params.c lp_presolve.c lp_price.c lp_pricePSE.c lp_report.c lp_scale.c lp_simplex.c lp_SOS.c lp_utils.c yacc_read.c)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN 1)
 target_link_libraries(${PROJECT_NAME} dl m)
 
 add_executable(${PROJECT_NAME}_exe lp_solve/lp_solve.c)

--- a/lpsolve.patch
+++ b/lpsolve.patch
@@ -1,0 +1,11 @@
+--- lp_types.h	2009-10-12 21:37:24.000000000 +0200
++++ lp_types.h	2020-02-06 09:44:27.595074632 +0100
+@@ -140,7 +140,7 @@
+ 
+   #else
+ 
+-    #define __EXPORT_TYPE
++      #define __EXPORT_TYPE __attribute__((visibility("default"))) 
+ 
+   #endif
+ 


### PR DESCRIPTION
This PR limits the symbols exported by the shared library `liblpsolve` to just the public API. This solves a bug where both `liblpsolve` and `libogdi` export a symbol named `mat_free`. The internal references in `liblpsolve` get linked to the wrong one at runtime leading to hard to debug segmentation faults.